### PR TITLE
add missing captcha js lib

### DIFF
--- a/class.tx_jmrecaptcha.php
+++ b/class.tx_jmrecaptcha.php
@@ -79,7 +79,9 @@ class tx_jmrecaptcha extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 	 * @return string
 	 */
 	protected function renderNoCaptcha() {
-		return '<div class="g-recaptcha" data-sitekey="' . htmlspecialchars($this->conf['public_key']) . '"></div>';
+		$content = '<script type="text/javascript" src="' . htmlspecialchars($this->conf['server']) . '.js"></script>';
+		$content.= '<div class="g-recaptcha" data-sitekey="' . htmlspecialchars($this->conf['public_key']) . '"></div>';
+		return $content;
 	}
 
 	/**


### PR DESCRIPTION
The new captcha 2.0 doesn't show up, because the js lib wasn't included for the `nocaptcha` type.
Analogous to the `recaptcha` captcha type, I added the `<script>` include to the `renderNoCaptcha` method.
