### PR TITLE
[BUGFIX] Fix broken NoCAPTCHA output

### DIFF
--- a/class.tx_jmrecaptcha.php
+++ b/class.tx_jmrecaptcha.php
@@ -79,7 +79,9 @@ class tx_jmrecaptcha extends \TYPO3\CMS\Frontend\Plugin\AbstractPlugin {
 	 * @return string
 	 */
 	protected function renderNoCaptcha() {
-		return '<div class="g-recaptcha" data-sitekey="' . htmlspecialchars($this->conf['public_key']) . '"></div>';
+		$content = '<script type="text/javascript" src="' . htmlspecialchars($this->conf['server']) . '.js?hl=' . htmlspecialchars($this->conf['lang']) . '"></script>';
+		$content .= '<div class="g-recaptcha" data-sitekey="' . htmlspecialchars($this->conf['public_key']) . '" data-theme="' . htmlspecialchars($this->conf['theme']) . '"></div>';
+		return $content;
 	}
 
 	/**

--- a/ext_typoscript_constants.txt
+++ b/ext_typoscript_constants.txt
@@ -21,8 +21,8 @@ plugin.tx_jmrecaptcha {
 	# cat=plugin.recaptcha/enable/07; type=boolean; label= Force SSL: Force use of SSL (api_server_secure)
 	use_ssl = 0
 
-	# cat=plugin.recaptcha//08; type=options[,red,white,blackglass,clean,custom]; label= reCAPTCHA Theme: Predefined reCAPTCHA themes
-	theme = red
+	# cat=plugin.recaptcha//08; type=options[light,dark,red,white,blackglass,clean,custom]; label= reCAPTCHA Theme: Predefined reCAPTCHA themes (dark, light only for NoCaptcha)
+	theme =
 
 	# cat=plugin.recaptcha//09; type=int+; label= reCAPTCHA TabIndex: TabIndex of reCAPTCHA field
 	tabindex = 0


### PR DESCRIPTION
- Add missing JavaScript API integration
- Add missing transfer from "lang"-config into the frontend
- Add missing transfer from "theme"-config into the frontend
- Set default theme to empty in TypoScript constants, since captcha_type nocaptcha is default
